### PR TITLE
Warn if pallet provided to try-state does not exist (#13858)

### DIFF
--- a/frame/support/src/traits/try_runtime.rs
+++ b/frame/support/src/traits/try_runtime.rs
@@ -168,11 +168,19 @@ impl<BlockNumber: Clone + sp_std::fmt::Debug + AtLeast32BitUnsigned> TryState<Bl
 					#( (<Tuple as crate::traits::PalletInfoAccess>::name(), Tuple::try_state) ),*
 				)];
 				let mut result = Ok(());
-				for (name, try_state_fn) in try_state_fns {
-					if pallet_names.iter().any(|n| n == name.as_bytes()) {
+				pallet_names.iter().for_each(|pallet_name| {
+					if let Some((name, try_state_fn)) =
+						try_state_fns.iter().find(|(name, _)| name.as_bytes() == pallet_name)
+					{
 						result = result.and(try_state_fn(n.clone(), targets.clone()));
+					} else {
+						crate::log::warn!(
+							"Pallet {:?} not found",
+							sp_std::str::from_utf8(pallet_name).unwrap_or_default()
+						);
 					}
-				}
+				});
+
 				result
 			},
 		}


### PR DESCRIPTION
* Warn if pallet does not exist in try-state

* unwrap_or_default



✄ -----------------------------------------------------------------------------

Thank you for your Pull Request! 🙏

Before you submit, please check that:

- [ ] **Description:** You added a brief description of the PR, e.g.:
  - What does it do?
  - What important points should reviewers know?
  - Is there something left for follow-up PRs?
- [ ] **Labels:** You labeled the PR appropriately if you have permissions to do so:
  - [ ] `A*` for PR status (**one required**)
  - [ ] `B*` for changelog (**one required**)
  - [ ] `C*` for release notes (**exactly one required**)
  - [ ] `D*` for various implications/requirements
  - [ ] Github project assignment
- [ ] **Related Issues:** You mentioned a related issue if this PR is related to it, e.g. `Fixes #228` or `Related #1337`.
- [ ] **2 Reviewers:** You asked at least two reviewers to review. If you aren't sure, start with GH suggestions.
- [ ] **Style Guide:** Your PR adheres to [the style guide](https://github.com/paritytech/substrate/blob/master/docs/STYLE_GUIDE.md)
  - In particular, mind the maximal line length of 100 (120 in exceptional circumstances).
  - There is no commented code checked in unless necessary.
  - Any panickers in the runtime have a proof or were removed.
- [ ] **Runtime Version:** You bumped the runtime version if there are breaking changes in the **runtime**.
- [ ] **Docs:** You updated any rustdocs which may need to change.
- [ ] **Polkadot Companion:** Has the PR altered the external API or interfaces used by Polkadot?
  - [ ] If so, do you have the corresponding Polkadot PR ready?
  - [ ] Optionally: Do you have a corresponding Cumulus PR?

Refer to [the contributing guide](https://github.com/paritytech/substrate/blob/master/docs/CONTRIBUTING.adoc) for details.

After you've read this notice feel free to remove it.
Thank you!

✄ -----------------------------------------------------------------------------
